### PR TITLE
Increase minSdk to 23

### DIFF
--- a/app/prodRelease-badging.txt
+++ b/app/prodRelease-badging.txt
@@ -1,5 +1,5 @@
 package: name='com.google.samples.apps.nowinandroid' versionCode='8' versionName='0.1.2' platformBuildVersionName='14' platformBuildVersionCode='34' compileSdkVersion='34' compileSdkVersionCodename='14'
-sdkVersion:'21'
+sdkVersion:'23'
 targetSdkVersion:'34'
 uses-permission: name='android.permission.INTERNET'
 uses-permission: name='android.permission.ACCESS_NETWORK_STATE'

--- a/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt
@@ -36,7 +36,7 @@ internal fun Project.configureKotlinAndroid(
         compileSdk = 34
 
         defaultConfig {
-            minSdk = 21
+            minSdk = 23
         }
 
         compileOptions {


### PR DESCRIPTION
In prep for snapshots, bump minSdk to 23 and store golden for badging test.