### PR TITLE
Add Emerge snapshot testing

### DIFF
--- a/.github/workflows/Snapshots.yml
+++ b/.github/workflows/Snapshots.yml
@@ -1,0 +1,31 @@
+name: Emerge Snapshots
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  snapshots:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: .
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Emerge snapshots
+        run: ./gradlew :app:emergeUploadSnapshotBundleDemoDebug -Pandroid.useAndroidX=true
+        env:
+          EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_TOKEN }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,6 +25,22 @@ plugins {
     id("com.google.android.gms.oss-licenses-plugin")
     alias(libs.plugins.baselineprofile)
     alias(libs.plugins.roborazzi)
+    alias(libs.plugins.emerge)
+}
+
+emerge {
+    // API token automatically set by the EMERGE_API_TOKEN environment variable
+
+    snapshots {
+        tag.set("snapshot")
+    }
+
+    vcs {
+        gitHub {
+            repoName.set("nowinandroid")
+            repoOwner.set("EmergeTools")
+        }
+    }
 }
 
 android {
@@ -122,6 +138,7 @@ dependencies {
     testDemoImplementation(libs.roborazzi)
     testDemoImplementation(projects.core.screenshotTesting)
 
+    androidTestImplementation(libs.emerge.snapshots)
     androidTestImplementation(projects.core.testing)
     androidTestImplementation(projects.core.dataTest)
     androidTestImplementation(projects.core.datastoreTest)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ androidxWindowManager = "1.3.0-alpha03"
 androidxWork = "2.9.0"
 coil = "2.6.0"
 dependencyGuard = "0.5.0"
+emergeGradlePlugin = "3.0.0"
 emergeSnapshots = "1.0.0"
 firebaseBom = "32.4.0"
 firebaseCrashlyticsPlugin = "2.9.9"
@@ -110,6 +111,7 @@ androidx-work-testing = { group = "androidx.work", name = "work-testing", versio
 coil-kt = { group = "io.coil-kt", name = "coil", version.ref = "coil" }
 coil-kt-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 coil-kt-svg = { group = "io.coil-kt", name = "coil-svg", version.ref = "coil" }
+emerge-snapshots = { module = "com.emergetools.snapshots:snapshots", version.ref = "emergeSnapshots" }
 emerge-snapshots-annotations = { module = "com.emergetools.snapshots:snapshots-annotations", version.ref = "emergeSnapshots" }
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics-ktx" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
@@ -160,6 +162,7 @@ android-library = { id = "com.android.library", version.ref = "androidGradlePlug
 android-test = { id = "com.android.test", version.ref = "androidGradlePlugin" }
 baselineprofile = { id = "androidx.baselineprofile", version.ref = "androidxMacroBenchmark"}
 dependencyGuard = { id = "com.dropbox.dependency-guard", version.ref = "dependencyGuard" }
+emerge = { id = "com.emergetools.android", version.ref = "emergeGradlePlugin" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }
 firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerfPlugin" }
 gms = { id = "com.google.gms.google-services", version.ref = "gmsPlugin" }


### PR DESCRIPTION
Adds Emerge snapshot testing and a simple workflow to invoke the snapshot testing Gradle task.

A failure is expected to be posted here as there's no base build to compare against. Once we merge this, all future PRs will have a valid base to compare against, and we'll get real snapshot diffs!