### PR TITLE
Interests card - Remove image background and center text when missing description

### DIFF
--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/InterestsItem.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/InterestsItem.kt
@@ -16,11 +16,9 @@
 
 package com.google.samples.apps.nowinandroid.core.ui
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
@@ -29,7 +27,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.selected

--- a/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/InterestsItem.kt
+++ b/core/ui/src/main/kotlin/com/google/samples/apps/nowinandroid/core/ui/InterestsItem.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
@@ -28,6 +29,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.selected
@@ -60,7 +62,9 @@ fun InterestsItem(
             Text(text = name)
         },
         supportingContent = {
-            Text(text = description)
+            if (description.isNotEmpty()) {
+                Text(text = description)
+            }
         },
         trailingContent = {
             NiaIconToggleButton(
@@ -103,9 +107,7 @@ fun InterestsItem(
 private fun InterestsIcon(topicImageUrl: String, modifier: Modifier = Modifier) {
     if (topicImageUrl.isEmpty()) {
         Icon(
-            modifier = modifier
-                .background(MaterialTheme.colorScheme.surface)
-                .padding(4.dp),
+            modifier = modifier.padding(4.dp),
             imageVector = NiaIcons.Person,
             // decorative image
             contentDescription = null,


### PR DESCRIPTION
Just some small UI tweaks! 

The expected UI change (from Android studio Previews) is attached here, only the bottom two should change - Emerge snapshots should confirm!

| Before | After |
|--------|-------|
| <img width="300" alt="Screenshot 2024-05-30 at 9 25 46 AM" src="https://github.com/EmergeTools/nowinandroid/assets/6821566/e8f587af-9022-4ec3-a407-ac6b66b24a55"> | <img width="304" alt="Screenshot 2024-05-30 at 9 25 34 AM" src="https://github.com/EmergeTools/nowinandroid/assets/6821566/e3f0bda9-5ecd-48d4-a7a3-aebba57e6b0c"> |